### PR TITLE
Tweaks to run on Raspberry Pi / Linux

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,9 +28,8 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "RaspberryPiDeploy",
-            "program": "~/dotnet/dotnet",
+            "program": "./AirDropAnywhere.Cli",
             "args": [
-                "AirDropAnywhere.Cli.dll",
                 "server",
                 "--port",
                 "8080"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/net5.0/${workspaceFolderBasename}.dll",
+            "program": "${workspaceFolder}/bin/Debug/net6.0/${workspaceFolderBasename}.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -28,21 +28,32 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "RaspberryPiDeploy",
-            "program": "dotnet",
+            "program": "~/dotnet/dotnet",
             "args": [
-                "/home/pi/src/${workspaceFolderBasename}/AirDropAnywhere.Cli.dll"
+                "AirDropAnywhere.Cli.dll",
+                "server",
+                "--port",
+                "8080"
             ],
-            "cwd": "/home/pi/src/${workspaceFolderBasename}",
+            "cwd": "~/src/${workspaceFolderBasename}",
             "stopAtEntry": false,
             "console": "internalConsole",
             "pipeTransport": {
                 "pipeCwd": "${workspaceFolder}",
                 "pipeProgram": "ssh",
                 "pipeArgs": [
-                    "pi@dward-pi"
+                    "pi@${input:host}"
                 ],
-                "debuggerPath": "/home/pi/vsdbg/vsdbg"
+                "debuggerPath": "~/vsdbg/vsdbg"
             }
+        }
+    ],
+    "inputs": [
+        {
+            "id": "host",
+            "description": "Raspberry Pi host to debug",
+            "default": "dward-pi",
+            "type": "promptString"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,7 +46,7 @@
                 "publish",
                 "-r:linux-arm",
                 "-o:bin/linux-arm/publish",
-                "--no-self-contained"
+                "--self-contained"
             ],
             "problemMatcher": "$msCompile"
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -58,8 +58,16 @@
                 "reveal": "always",
                 "panel": "new"
             },
-            "command": "rsync -rvuz --rsh=ssh bin/linux-arm/publish/ pi@dward-pi:~/src/${workspaceFolderBasename}/",
-            "problemMatcher": []
+            "command": "rsync -rvuz --rsh=ssh bin/linux-arm/publish/ pi@${input:host}:~/src/${workspaceFolderBasename}/",
+            "problemMatcher": [],
+        }
+    ],
+    "inputs": [
+        {
+            "id": "host",
+            "description": "Raspberry Pi host to deploy to",
+            "default": "dward-pi",
+            "type": "promptString"
         }
     ]
 }

--- a/build/enableRemoteDebugging.sh
+++ b/build/enableRemoteDebugging.sh
@@ -57,7 +57,7 @@ else
     exit
 fi
 
-if [ -x "~/.ssh/id_rsa" ]; then
+if [ ! -f ~/.ssh/id_rsa_yubikey.pub -a ! -f ~/.ssh/id_rsa ]; then
     cat << EOM
 --------------------------------------------------------------
 |                                                            |
@@ -100,7 +100,11 @@ cat << EOM
 |                                                            |
 --------------------------------------------------------------
 EOM
-cat ~/.ssh/id_rsa.pub | ssh -oStrictHostKeyChecking=no pi@$PI_HOSTNAME "cat >> ~/.ssh/authorized_keys"
+if [ -f ~/.ssh/id_rsa_yubikey.pub ]; then
+    cat ~/.ssh/id_rsa_yubikey.pub | ssh -oStrictHostKeyChecking=no pi@$PI_HOSTNAME "cat >> ~/.ssh/authorized_keys"
+else
+    cat ~/.ssh/id_rsa.pub | ssh -oStrictHostKeyChecking=no pi@$PI_HOSTNAME "cat >> ~/.ssh/authorized_keys"
+fi
 echo "${green:-}Added public key to authorized_keys on '$PI_HOSTNAME'!${normal:-}"
 
 cat << EOM

--- a/src/AirDropAnywhere.Cli/Commands/ServerCommand.cs
+++ b/src/AirDropAnywhere.Cli/Commands/ServerCommand.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AirDropAnywhere.Cli.Hubs;
 using AirDropAnywhere.Cli.Logging;
+using AirDropAnywhere.Core.Certificates;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -27,6 +28,12 @@ namespace AirDropAnywhere.Cli.Commands
         {
             var webHost = default(IWebHost);
             using var cancellationTokenSource = new CancellationTokenSource();
+
+            Logger.LogInformation(
+                "Generating self-signed certificate for HTTPS"
+            );
+
+            using var cert = CertificateManager.Create();
             
             await Console.Status()
                 .Spinner(Spinner.Known.Earth)
@@ -34,6 +41,7 @@ namespace AirDropAnywhere.Cli.Commands
                     "Starting AirDrop services...",
                     async _ =>
                     {
+                        
                         webHost = WebHost.CreateDefaultBuilder()
                             .ConfigureLogging(
                                 (hostContext, builder) =>
@@ -44,7 +52,7 @@ namespace AirDropAnywhere.Cli.Commands
                                 }
                             )
                             .ConfigureKestrel(
-                                options => options.ConfigureAirDropDefaults()
+                                options => options.ConfigureAirDropDefaults(cert)
                             )
                             .ConfigureServices(
                                 (hostContext, services) =>

--- a/src/AirDropAnywhere.Core/AirDropKestrelExtensions.cs
+++ b/src/AirDropAnywhere.Core/AirDropKestrelExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
 using AirDropAnywhere.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,14 +17,19 @@ namespace Microsoft.AspNetCore.Hosting
         /// Configures AirDrop defaults for Kestrel.
         /// </summary>
         /// <param name="options">A <see cref="KestrelServerOptions"/> instance to configure.</param>
-        public static void ConfigureAirDropDefaults(this KestrelServerOptions options)
+        /// <param name="cert">An <see cref="X509Certificate2"/> representing the certificate to use for the AirDrop HTTPS endpoint.</param>
+        public static void ConfigureAirDropDefaults(this KestrelServerOptions options, X509Certificate2 cert)
         {
+            if (cert == null)
+            {
+                throw new ArgumentNullException(nameof(cert));
+            }
+            
             var airDropOptions = options.ApplicationServices.GetRequiredService<IOptions<AirDropOptions>>();
             options.ConfigureEndpointDefaults(
                 endpointDefaults =>
                 {
-                    // TODO: use a self-generated certificate
-                    endpointDefaults.UseHttps();
+                    endpointDefaults.UseHttps(cert);
                 });
 
             options.ListenAnyIP(airDropOptions.Value.ListenPort);

--- a/src/AirDropAnywhere.Core/Certificates/CertificateManager.cs
+++ b/src/AirDropAnywhere.Core/Certificates/CertificateManager.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace AirDropAnywhere.Core.Certificates
+{
+    /// <summary>
+    /// Generates a self-signed certificate for the AirDrop HTTPS endpoint.
+    /// </summary>
+    public static class CertificateManager
+    {
+        /// <summary>
+        /// This OID is in the badly-documented "private" range based upon this ServerFault
+        /// answer: https://serverfault.com/a/861475. We should be fine to use this
+        /// as it's only used for our own ephemeral self-signed certificate.
+        /// </summary>
+        private const string AirDropHttpsOid = "1.3.9999.1.1";
+        private const string AirDropHttpsOidFriendlyName = "AirDrop Anywhere HTTPS certificate";
+
+        private const string ServerAuthenticationEnhancedKeyUsageOid = "1.3.6.1.5.5.7.3.1";
+        private const string ServerAuthenticationEnhancedKeyUsageOidFriendlyName = "Server Authentication";
+        private const string AirDropHttpsDnsName = "airdrop.local";
+        private const string AirDropHttpsDistinguishedName = "CN=" + AirDropHttpsDnsName;
+
+        /// <summary>
+        /// Creates a self-signed certificate suitable for serving requests over
+        /// AirDrop's HTTPS endpoint
+        /// </summary>
+        /// <returns>
+        /// An <see cref="X509Certificate2"/> representing the self-signed certificate. 
+        /// </returns>
+        public static X509Certificate2 Create()
+        {
+            // TODO: make this CreateOrGet so we don't keep generating a new certificate 
+            // everytime the service starts. We can store the created certificate in the 
+            // user's private X509 store
+            return CreateCertificate(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
+        }
+        
+        /// <summary>
+        /// This method is largely lifted from the code used to generate self-signed 
+        /// X509 certificates in the .NET SDK. See https://github.com/dotnet/aspnetcore/blob/main/src/Shared/CertificateGeneration/CertificateManager.cs
+        /// </summary>
+        private static X509Certificate2 CreateCertificate(DateTimeOffset notBefore, DateTimeOffset notAfter)
+        {
+            var subject = new X500DistinguishedName(AirDropHttpsDistinguishedName);
+            var extensions = new List<X509Extension>();
+            var sanBuilder = new SubjectAlternativeNameBuilder();
+            sanBuilder.AddDnsName(AirDropHttpsDnsName);
+
+            var keyUsage = new X509KeyUsageExtension(X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DigitalSignature, critical: true);
+            var enhancedKeyUsage = new X509EnhancedKeyUsageExtension(
+                new OidCollection
+                {
+                    new(
+                        ServerAuthenticationEnhancedKeyUsageOid,
+                        ServerAuthenticationEnhancedKeyUsageOidFriendlyName
+                    )
+                },
+                critical: true);
+
+            var basicConstraints = new X509BasicConstraintsExtension(
+                certificateAuthority: false,
+                hasPathLengthConstraint: false,
+                pathLengthConstraint: 0,
+                critical: true
+            );
+
+            var bytePayload = Encoding.ASCII.GetBytes(AirDropHttpsOidFriendlyName);
+            var aspNetHttpsExtension = new X509Extension(
+                new AsnEncodedData(
+                    new Oid(AirDropHttpsOid, AirDropHttpsOidFriendlyName),
+                    bytePayload),
+                critical: false);
+
+            extensions.Add(basicConstraints);
+            extensions.Add(keyUsage);
+            extensions.Add(enhancedKeyUsage);
+            extensions.Add(sanBuilder.Build(critical: true));
+            extensions.Add(aspNetHttpsExtension);
+
+            var certificate = CreateSelfSignedCertificate(subject, extensions, notBefore, notAfter);
+            return certificate;
+        }
+
+        private static X509Certificate2 CreateSelfSignedCertificate(
+            X500DistinguishedName subject,
+            IEnumerable<X509Extension> extensions,
+            DateTimeOffset notBefore,
+            DateTimeOffset notAfter
+        )
+        {
+            using var key = CreateKeyMaterial(4096);
+
+            var request = new CertificateRequest(subject, key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            foreach (var extension in extensions)
+            {
+                request.CertificateExtensions.Add(extension);
+            }
+
+            var result = request.CreateSelfSigned(notBefore, notAfter);
+            return result;
+
+            RSA CreateKeyMaterial(int minimumKeySize)
+            {
+                var rsa = RSA.Create(minimumKeySize);
+                if (rsa.KeySize < minimumKeySize)
+                {
+                    throw new InvalidOperationException($"Failed to create a key with a size of {minimumKeySize} bits");
+                }
+
+                return rsa;
+            }
+        }
+        
+        private static bool IsValidCertificate(X509Certificate2 certificate, DateTimeOffset currentDate) =>
+            certificate.NotBefore <= currentDate &&
+            currentDate <= certificate.NotAfter;
+        
+        private static bool HasOid(X509Certificate2 certificate, string oid) =>
+            certificate.Extensions
+                .Any(e => string.Equals(oid, e.Oid?.Value, StringComparison.Ordinal));
+
+    }
+}

--- a/src/AirDropAnywhere.Core/Utils.cs
+++ b/src/AirDropAnywhere.Core/Utils.cs
@@ -39,7 +39,7 @@ namespace AirDropAnywhere.Core
             if (!hasAwdlInterface)
             {
                 throw new InvalidOperationException(
-                    "No awdl0 interface found on this system. AirDrop Anywhere is currently only supported on systems that support the AWDL protocol."
+                    "No awdl0 interface found on this system. AirDrop Anywhere is currently only supported on systems that support the AWDL or OWL protocol."
                 );
             }
         }

--- a/src/AirDropAnywhere.Core/Utils.cs
+++ b/src/AirDropAnywhere.Core/Utils.cs
@@ -22,10 +22,10 @@ namespace AirDropAnywhere.Core
         public static void AssertPlatform()
         {
             // TODO: support linux
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 throw new InvalidOperationException(
-                    "AirDropAnywhere is currently only supported on MacOS because it needs support for the AWDL protocol."
+                    "AirDropAnywhere is currently only supported on MacOS or Linux because it needs support for either the AWDL or OWL protocol."
                 );
             }
         }
@@ -39,7 +39,7 @@ namespace AirDropAnywhere.Core
             if (!hasAwdlInterface)
             {
                 throw new InvalidOperationException(
-                    "No awdl0 interface found on this system. AirDrop.NET is currently only supported on systems that support the AWDL protocol."
+                    "No awdl0 interface found on this system. AirDrop Anywhere is currently only supported on systems that support the AWDL protocol."
                 );
             }
         }
@@ -55,7 +55,7 @@ namespace AirDropAnywhere.Core
         {
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
             
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 return;
             }


### PR DESCRIPTION
After configuring a Raspberry Pi with an RFMON (active monitor) mode capable wifi adapter and running [OWL](https://github.com/seemoo-lab/owl) this PR makes the necessary changes to gracefully run AirDrop Anywhere in that environment.

First, it makes minor tweaks to how listener sockets are bound in the mDNS server (certain socket options are not supported in Linux, only MacOS). Next it tweaks the deployment mechanism to remotely debug on a Raspberry Pi (using a self-contained application so .NET does not need to be installed on the device) and adds support for SSH authentication during that deployment using a YubiKey. Finally, because of the self-contained deployment it adds support for generating a self-signed HTTPS certificate - when the .NET SDK is not installed `dotnet dev-certs` is not available and we are no longer able to rely on the ASP.NET Development Certificate.

Longer term we'll store the HTTPS certificate in the user's certificate store but, for now, we generate a new one each time the application is started.

Good news is that this now works on a Raspberry Pi, partially addressing #11 .

Next up here is to add support for running the application as a systemd daemon.