### PR TITLE
mDNS Discovery

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Auto detect text files and perform LF normalization
+*   text=auto
+sh  text eol=lf

--- a/AirDropAnywhere.sln.DotSettings
+++ b/AirDropAnywhere.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=AWDL/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unicast/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,8 @@
     <IncludeSymbols>false</IncludeSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/src/AirDropAnywhere.Cli/AirDropAnywhere.Cli.csproj
+++ b/src/AirDropAnywhere.Cli/AirDropAnywhere.Cli.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AirDropAnywhere.Cli/AsyncEnumerable.cs
+++ b/src/AirDropAnywhere.Cli/AsyncEnumerable.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AirDropAnywhere.Cli
+{
+    internal static class AsyncEnumerable
+    {
+        /// <summary>
+        /// Returns the first element of an <see cref="IAsyncEnumerable{T}"/>.
+        /// </summary>
+        /// <param name="source">
+        /// <see cref="IAsyncEnumerable{T}"/> to enumerate.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// <see cref="CancellationToken"/> used to cancel the operation
+        /// </param>
+        /// <typeparam name="T">
+        /// Type of element in the <see cref="IAsyncEnumerable{T}"/>
+        /// </typeparam>
+        /// <returns>
+        /// First element or <c>default</c> if none was found.
+        /// </returns>
+        public static async ValueTask<T?> FirstOrDefaultAsync<T>(this IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+        {
+            await using var e = source.GetAsyncEnumerator(cancellationToken);
+            if (await e.MoveNextAsync())
+            {
+                return e.Current;
+            }
+
+            return default;
+        }
+        
+    }
+}

--- a/src/AirDropAnywhere.Cli/Commands/ClientCommand.cs
+++ b/src/AirDropAnywhere.Cli/Commands/ClientCommand.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Net.NetworkInformation;
 using System.Net.Security;
 using System.Text;
 using System.Text.Json;
@@ -251,13 +250,14 @@ namespace AirDropAnywhere.Cli.Commands
             Logger.LogInformation("Downloaded '{File}'...", request.Name);
         }
 
+        // ReSharper disable once ClassNeverInstantiated.Global
         public class Settings : CommandSettings
         {
             [CommandOption("--server")]
             public string Server { get; internal set; } = null!;
             
             [CommandOption("--port")]
-            public ushort Port { get; internal set; } = default!;
+            public ushort Port { get; internal set; }
 
             [CommandOption("--path")]
             public string Path { get; init; } = null!;

--- a/src/AirDropAnywhere.Cli/Commands/ServerCommand.cs
+++ b/src/AirDropAnywhere.Cli/Commands/ServerCommand.cs
@@ -168,6 +168,7 @@ namespace AirDropAnywhere.Cli.Commands
             return 0;
         }
         
+        // ReSharper disable once ClassNeverInstantiated.Global
         public class Settings : CommandSettings
         {
             [CommandOption("--port")]

--- a/src/AirDropAnywhere.Cli/Commands/ServerCommand.cs
+++ b/src/AirDropAnywhere.Cli/Commands/ServerCommand.cs
@@ -3,9 +3,9 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using AirDropAnywhere.Cli.Certificates;
 using AirDropAnywhere.Cli.Hubs;
 using AirDropAnywhere.Cli.Logging;
-using AirDropAnywhere.Core.Certificates;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -20,20 +20,21 @@ namespace AirDropAnywhere.Cli.Commands
 {
     internal class ServerCommand : CommandBase<ServerCommand.Settings>
     {
-        public ServerCommand(IAnsiConsole console, ILogger<ServerCommand> logger) : base(console, logger)
+        private readonly CertificateManager _certificateManager;
+
+        public ServerCommand(
+            IAnsiConsole console, 
+            ILogger<ServerCommand> logger, 
+            CertificateManager certificateManager
+        ) : base(console, logger)
         {
+            _certificateManager = certificateManager ?? throw new ArgumentNullException(nameof(certificateManager));
         }
 
         public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
         {
             var webHost = default(IWebHost);
             using var cancellationTokenSource = new CancellationTokenSource();
-
-            Logger.LogInformation(
-                "Generating self-signed certificate for HTTPS"
-            );
-
-            using var cert = CertificateManager.Create();
             
             await Console.Status()
                 .Spinner(Spinner.Known.Earth)
@@ -52,8 +53,12 @@ namespace AirDropAnywhere.Cli.Commands
                                 }
                             )
                             .ConfigureKestrel(
-                                options => options.ConfigureAirDropDefaults(cert)
-                            )
+                                options =>
+                                {
+                                    options.ConfigureAirDropDefaults(
+                                        _certificateManager.GetOrCreate()
+                                    );
+                                })
                             .ConfigureServices(
                                 (hostContext, services) =>
                                 {

--- a/src/AirDropAnywhere.Cli/Configuration.cs
+++ b/src/AirDropAnywhere.Cli/Configuration.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Configuration;
+
+namespace AirDropAnywhere.Cli
+{
+    internal static class Configuration
+    {
+        private static IConfiguration? _default;
+        public static IConfiguration Default => _default ??= new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", true, true)
+            .Build();
+
+        public static IConfiguration Logging => Default.GetSection("Logging");
+    }
+}

--- a/src/AirDropAnywhere.Cli/Http/HttpHandlerFactory.cs
+++ b/src/AirDropAnywhere.Cli/Http/HttpHandlerFactory.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AirDropAnywhere.Cli.Http
+{
+    /// <summary>
+    /// Helpers used to configure an <see cref="HttpClient"/> used for AirDrop.
+    /// </summary>
+    internal static class HttpHandlerFactory
+    {
+        /// <summary>
+        /// Creates an <see cref="SocketsHttpHandler"/> with default settings
+        /// for connecting to AirDrop SignalR and HTTP endpoints.
+        /// </summary>
+        /// <returns>
+        /// An instance of <see cref="SocketsHttpHandler"/>.
+        /// </returns>
+        public static SocketsHttpHandler Create() => new()
+        {
+            ConnectTimeout = _defaultConnectTimeout,
+            SslOptions = new SslClientAuthenticationOptions
+            {
+                // ignore TLS certificate errors - we're deliberately
+                // using self-signed certificates so no need to worry
+                // about validating them here
+                RemoteCertificateValidationCallback = IgnoreRemoteCertificateValidator
+            }
+        };
+        
+        /// <summary>
+        /// Default timeout used when connecting to an AirDrop HTTP endpoint.
+        /// </summary>
+        private static readonly TimeSpan _defaultConnectTimeout = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Implementation of <see cref="RemoteCertificateValidationCallback"/> that
+        /// ignores the validity of a remote certificate. 
+        /// </summary>
+        // TODO: update to validate the certificate based upon a previously user-validated setting
+        public static readonly RemoteCertificateValidationCallback IgnoreRemoteCertificateValidator =
+            delegate { return true; };
+
+
+        private static readonly ConcurrentDictionary<(string, int, AddressFamily), IPEndPoint> _hostMappings = new();
+        
+        /// <summary>
+        /// Implementation of <see cref="SocketsHttpHandler.ConnectCallback"/> that attempts to connect
+        /// to any of the IP addresses that a <see cref="DnsEndPoint"/> resolves to.
+        /// </summary>
+        private static readonly Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>>
+            _defaultConnectCallback = async (ctx, cancellationToken) =>
+            {
+                // when .NET attempts to connect to a DNS endpoint
+                // it appears to naively pick the first IPv4 or IPv6 record
+                // it resolves to, irrespective of the reachability of the underlying
+                // address. When resolving using mDNS, depending on the network interfaces
+                // available to the system that registered the DNS entry, we can often
+                // have multiple IPv4 or IPv6 addresses returned to the resolver. If
+                // .NET picks one that is not reachable to the client system then
+                // connectivity to the endpoint will fail.
+                //
+                // This alternate connect callback attempts to connect to each resolved
+                // IP address until it finds one that can be successfully connected to.
+                var dnsEndPoint = ctx.DnsEndPoint;
+                var mappingKey = (dnsEndPoint.Host, dnsEndPoint.Port, dnsEndPoint.AddressFamily);
+                if (_hostMappings.TryGetValue(mappingKey, out var ipEndPoint))
+                {
+                    // we found an existing mapping between the host and an IP address, use it!
+                    var (socket, _) = await ConnectAsync(ipEndPoint, cancellationToken);
+                    if (socket != null)
+                    {
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    
+                    // otherwise something went wrong, try to lookup again and fail if necessary...
+                }
+                
+                var ipAddresses = await Dns.GetHostAddressesAsync(dnsEndPoint.Host).ConfigureAwait(false);
+                var lastError = default(Exception?);
+                foreach (var ipAddress in ipAddresses)
+                {
+                    if (dnsEndPoint.AddressFamily != AddressFamily.Unspecified && ipAddress.AddressFamily != dnsEndPoint.AddressFamily)
+                    {
+                        // ignore any addresses that don't match what was required
+                        // by the endpoint specified by the caller
+                        continue;
+                    }
+
+                    // give each connect operation less time than the overall cancellation token
+                    // so that we don't blow up prematurely
+                    using var timedSource = new CancellationTokenSource(_defaultConnectTimeout / ipAddresses.Length);
+                    using var aggregateSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timedSource.Token);
+
+                    ipEndPoint = new IPEndPoint(ipAddress, dnsEndPoint.Port);
+                    var (socket, error) = await ConnectAsync(ipEndPoint, aggregateSource.Token);
+                    if (socket != null)
+                    {
+                        _hostMappings.AddOrUpdate(mappingKey, ipEndPoint, (_, _) => ipEndPoint);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+
+                    lastError = error;
+                }
+
+                // we couldn't connect to any of the endpoints, give up
+                throw lastError!;
+
+                static async ValueTask<(Socket? Socket, Exception? Error)> ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken)
+                {
+                    // Create and connect a socket using default settings.
+                    var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                    try
+                    {
+                        await socket.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        socket.Dispose();
+                        return (null, ex);
+                    }
+
+                    return (socket, null);
+                }
+            };
+    }
+}

--- a/src/AirDropAnywhere.Cli/Logging/SpectreInlineLoggerExtensions.cs
+++ b/src/AirDropAnywhere.Cli/Logging/SpectreInlineLoggerExtensions.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace AirDropAnywhere.Cli.Logging
+{
+    internal static class SpectreInlineLoggerExtensions
+    {
+        public static ILoggingBuilder AddSpectreConsole(this ILoggingBuilder builder) =>
+            builder.AddProvider(new SpectreInlineLoggerProvider(AnsiConsole.Console));
+    }
+}

--- a/src/AirDropAnywhere.Cli/Program.cs
+++ b/src/AirDropAnywhere.Cli/Program.cs
@@ -1,9 +1,10 @@
-﻿using System.Net.Http;
-using System.Net.Security;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using AirDropAnywhere.Cli.Certificates;
 using AirDropAnywhere.Cli.Commands;
+using AirDropAnywhere.Cli.Http;
 using AirDropAnywhere.Cli.Logging;
+using Microsoft.AspNetCore.HttpLogging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Spectre.Cli.Extensions.DependencyInjection;
@@ -18,27 +19,28 @@ namespace AirDropAnywhere.Cli
         public static Task<int> Main(string[] args)
         {
             var services = new ServiceCollection();
-                
+
             services
                 .AddHttpClient("airdrop")
                 .ConfigurePrimaryHttpMessageHandler(
-                    () => new SocketsHttpHandler
-                    {
-                        // we using a self-signed certificate, so ignore it
-                        SslOptions = new SslClientAuthenticationOptions
-                        {
-                            RemoteCertificateValidationCallback = delegate { return true; }
-                        }
-                    });
+                    HttpHandlerFactory.Create
+                );
             
             services
                 .AddSingleton(AnsiConsole.Console)
                 .AddSingleton<CertificateManager>()
+                .AddHttpLogging(
+                    options =>
+                    {
+                        options.LoggingFields = HttpLoggingFields.All;
+                    }
+                )
                 .AddLogging(
                     builder =>
                     {
                         builder.ClearProviders();
-                        builder.AddProvider(new SpectreInlineLoggerProvider(AnsiConsole.Console));
+                        builder.AddConfiguration(Configuration.Logging);
+                        builder.AddSpectreConsole();
                     }
                 );
 

--- a/src/AirDropAnywhere.Cli/Program.cs
+++ b/src/AirDropAnywhere.Cli/Program.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Net.Security;
 using System.Threading.Tasks;
+using AirDropAnywhere.Cli.Certificates;
 using AirDropAnywhere.Cli.Commands;
 using AirDropAnywhere.Cli.Logging;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,6 +33,7 @@ namespace AirDropAnywhere.Cli
             
             services
                 .AddSingleton(AnsiConsole.Console)
+                .AddSingleton<CertificateManager>()
                 .AddLogging(
                     builder =>
                     {

--- a/src/AirDropAnywhere.Cli/Properties/launchSettings.json
+++ b/src/AirDropAnywhere.Cli/Properties/launchSettings.json
@@ -10,7 +10,7 @@
     },
     "Client": {
       "commandName": "Project",
-      "commandLineArgs": "client --server localhost --port 8181 --path downloads",
+      "commandLineArgs": "client --path downloads",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Local"
       }

--- a/src/AirDropAnywhere.Core/MulticastDns/MulticastDnsManager.cs
+++ b/src/AirDropAnywhere.Core/MulticastDns/MulticastDnsManager.cs
@@ -9,6 +9,7 @@ using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Enclave.UdpPerf;
 using Makaretu.Dns;
@@ -17,9 +18,9 @@ using Makaretu.Dns.Resolving;
 namespace AirDropAnywhere.Core.MulticastDns
 {
     /// <summary>
-    /// Handles advertising mDNS services by responding to matching requests. 
+    /// Manages advertising and discovering mDNS services across one or more network interfaces. 
     /// </summary>
-    internal class MulticastDnsServer
+    public class MulticastDnsManager : IAsyncDisposable
     {
         private const int MulticastPort = 5353;
         // ReSharper disable InconsistentNaming
@@ -30,41 +31,144 @@ namespace AirDropAnywhere.Core.MulticastDns
         // ReSharper restore InconsistentNaming
 
         private readonly ImmutableArray<NetworkInterface> _networkInterfaces;
-        private readonly CancellationToken _cancellationToken;
         private readonly NameServer _nameServer;
 
+        private CancellationTokenSource? _cancellationTokenSource;
+        private ImmutableDictionary<Guid, ChannelWriter<Message>>? _responseHandlers;
         private ImmutableDictionary<AddressFamily, SocketListener>? _listeners;
         private ImmutableDictionary<AddressFamily, SocketClient>? _unicastClients;
         private ImmutableDictionary<(AddressFamily, int), SocketClient>? _multicastClients;
         private List<Task>? _listenerTasks;
 
-        public MulticastDnsServer(ImmutableArray<NetworkInterface> networkInterfaces, CancellationToken cancellationToken)
+        private MulticastDnsManager(ImmutableArray<NetworkInterface> networkInterfaces)
         {
             if (networkInterfaces.IsDefaultOrEmpty)
             {
                 throw new ArgumentException("Interfaces are required.", nameof(networkInterfaces));
             }
             
-            _networkInterfaces = networkInterfaces;
-            _cancellationToken = cancellationToken;
-            _nameServer = new NameServer()
+            _networkInterfaces = networkInterfaces.ToImmutableArray();
+            _nameServer = new NameServer
             {
                 Catalog = new Catalog()
             };
         }
 
-        public async ValueTask RegisterAsync(MulticastDnsService service)
+        /// <summary>
+        /// Creates a new instance of a <see cref="MulticastDnsManager"/>.
+        /// </summary>
+        /// <param name="networkInterfaces">
+        /// Network interfaces that the instance should bind to.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// <see cref="CancellationToken"/> used to teardown 
+        /// </param>
+        /// <returns></returns>
+        public static async ValueTask<MulticastDnsManager> CreateAsync(ImmutableArray<NetworkInterface> networkInterfaces, CancellationToken cancellationToken)
+        {
+            var mgr = new MulticastDnsManager(networkInterfaces);
+            await mgr.InitializeAsync(cancellationToken);
+            return mgr;
+        }
+
+        /// <summary>
+        /// Gets all multicast capable network interfaces that are currently _up_.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> of <see cref="NetworkInterface"/> objects.
+        /// </returns>
+        public static IEnumerable<NetworkInterface> GetMulticastInterfaces() =>
+            NetworkInterface.GetAllNetworkInterfaces()
+                .Where(i => i.SupportsMulticast)
+                .Where(i => i.OperationalStatus == OperationalStatus.Up)
+                .Where(i => i.NetworkInterfaceType != NetworkInterfaceType.Unknown)
+                .Where(i => i.NetworkInterfaceType != NetworkInterfaceType.Loopback)
+                .Where(i => i.NetworkInterfaceType != NetworkInterfaceType.Ppp);
+
+        /// <summary>
+        /// Discovers all instances of a service, resolving each one to the underlying
+        /// host and port that it is hosted on. 
+        /// </summary>
+        /// <param name="serviceName">
+        /// Name of a service to resolve, e.g. _airdrop_proxy._tcp
+        /// </param>
+        /// <returns>
+        /// An <see cref="IAsyncEnumerable{T}"/> of <see cref="DnsEndPoint"/> representing
+        /// </returns>
+        public async IAsyncEnumerable<DnsEndPoint> DiscoverAsync(string serviceName, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            var channel = Channel.CreateUnbounded<Message>();
+            var key = Guid.NewGuid();
+            var serviceDomain = DomainName.Join(serviceName, MulticastDnsService.Root);
+
+            // add a handler so responses can be dealt with...
+            _responseHandlers = _responseHandlers!.Add(key, channel.Writer);
+
+            static Message CreateQuery(DomainName name, DnsType type) => new()
+            {
+                Opcode = MessageOperation.Query,
+                Questions =
+                {
+                    new()
+                    {
+                        Name = name,
+                        Class = DnsClass.IN,
+                        Type = type
+                    }
+                }
+            };
+
+            // first up send a query for any PTR records associated with the service
+            await SendMulticastAsync(
+                CreateQuery(serviceDomain, DnsType.PTR)
+            );
+
+            // enumerate any responses for the query we sent
+            try
+            {
+                await foreach (var message in channel.Reader.ReadAllAsync(cancellationToken).WithCancellation(cancellationToken))
+                {
+                    foreach (var answer in message.Answers)
+                    {
+                        switch (answer)
+                        {
+                            case PTRRecord ptr when ptr.DomainName.IsSubdomainOf(serviceDomain):
+                                // we have a PTR record, use its data to query for any SRV records
+                                await SendMulticastAsync(
+                                    CreateQuery(ptr.DomainName, DnsType.SRV)
+                                );
+                                break;
+                            case SRVRecord srv when srv.Name.IsSubdomainOf(serviceDomain):
+                                // we have a SRV record - yield its target and port as a DnsEndPoint
+                                yield return new DnsEndPoint(srv.Target.ToString(), srv.Port);
+                                break;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                // we're done handling things, remove our handler
+                _responseHandlers = _responseHandlers.Remove(key);
+                
+                // and close down the channel so nothing else can be written to it
+                channel.Writer.Complete();
+            }
+        }
+
+                
+        internal async ValueTask RegisterAsync(MulticastDnsService service)
         {
             // add services to the name service
             // and pre-emptively announce ourselves across our multicast clients
             var catalog = _nameServer.Catalog;
             var msg = service.ToMessage();
-            
+
             catalog.Add(
                 new PTRRecord
                 {
                     DomainName = service.QualifiedServiceName,
-                    Name = MulticastDnsService.Discovery, 
+                    Name = MulticastDnsService.Discovery,
                     TTL = MulticastDnsService.DefaultTTL,
                 },
                 authoritative: true
@@ -78,30 +182,24 @@ namespace AirDropAnywhere.Core.MulticastDns
                 },
                 authoritative: true
             );
-            
+
             foreach (var resourceRecord in msg.Answers)
             {
                 catalog.Add(resourceRecord, authoritative: true);
             }
 
-            if (_multicastClients != null)
-            {
-                foreach (var client in _multicastClients.Values)
-                {
-                    await client.SendAsync(msg);
-                }
-            }
+            await SendMulticastAsync(msg);
         }
-        
-        public async ValueTask UnregisterAsync(MulticastDnsService service)
+
+        internal async ValueTask UnregisterAsync(MulticastDnsService service)
         {
             var catalog = _nameServer.Catalog;
-            
+
             // remove all services advertised under this name
             catalog.TryRemove(service.QualifiedServiceName, out _);
             catalog.TryRemove(service.QualifiedInstanceName, out _);
             catalog.TryRemove(service.HostName, out _);
-            
+
             // and pre-emptively announce ourselves with a 0 TTL
             var msg = service.ToMessage();
 
@@ -115,16 +213,10 @@ namespace AirDropAnywhere.Core.MulticastDns
                 additionalRecord.TTL = TimeSpan.Zero;
             }
 
-            if (_multicastClients != null)
-            {
-                foreach (var client in _multicastClients.Values)
-                {
-                    await client.SendAsync(msg);
-                }
-            }
+            await SendMulticastAsync(msg);
         }
         
-        public ValueTask StartAsync()
+        private ValueTask InitializeAsync(CancellationToken cancellationToken)
         {
             var multicastClients = ImmutableDictionary.CreateBuilder<(AddressFamily, int), SocketClient>();
             var unicastClients = ImmutableDictionary.CreateBuilder<AddressFamily, SocketClient>();
@@ -169,6 +261,8 @@ namespace AirDropAnywhere.Core.MulticastDns
                 }
             }
 
+            _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _responseHandlers = ImmutableDictionary<Guid, ChannelWriter<Message>>.Empty;
             _listeners = listeners.ToImmutable();
             _unicastClients = unicastClients.ToImmutable();
             _multicastClients = multicastClients.ToImmutable();
@@ -179,15 +273,21 @@ namespace AirDropAnywhere.Core.MulticastDns
             {
                 _listenerTasks.Add(
                     Task.Run(
-                        () => ListenAsync(listener), _cancellationToken
+                        () => ListenAsync(listener, _cancellationTokenSource.Token), _cancellationTokenSource.Token
                     )
                 );
             }
             return default;
         }
 
-        public async ValueTask StopAsync()
+        public async ValueTask DisposeAsync()
         {
+            if (_cancellationTokenSource != null)
+            {
+                _cancellationTokenSource.Cancel();
+                _cancellationTokenSource = null;
+            }
+
             if (_listenerTasks != null)
             {
                 await Task.WhenAll(_listenerTasks);
@@ -217,19 +317,25 @@ namespace AirDropAnywhere.Core.MulticastDns
                 }
             }
             
+            
             _listeners = null;
             _listenerTasks = null;
             _multicastClients = null;
             _unicastClients = null;
         }
 
-        private async Task ListenAsync(SocketListener listener)
+        private async Task ListenAsync(SocketListener listener, CancellationToken cancellationToken)
         {
-            await foreach (var receiveResult in listener.ReceiveAsync(_cancellationToken))
+            await foreach (var receiveResult in listener.ReceiveAsync(cancellationToken))
             {
                 var request = receiveResult.Message;
                 if (!request.IsQuery)
                 {
+                    // if we have response handlers then invoke them!
+                    foreach (var responseHandler in _responseHandlers!.Values)
+                    {
+                        await responseHandler.WriteAsync(request, cancellationToken);
+                    }
                     continue;
                 }
 
@@ -248,7 +354,7 @@ namespace AirDropAnywhere.Core.MulticastDns
                     }
                 }
 
-                var response = await _nameServer.ResolveAsync(request, _cancellationToken);
+                var response = await _nameServer.ResolveAsync(request, cancellationToken);
                 if (response.Status != MessageStatus.NoError)
                 {
                     // couldn't resolve the request, ignore it
@@ -279,7 +385,18 @@ namespace AirDropAnywhere.Core.MulticastDns
                 }
             }
         }
-
+        
+        private async ValueTask SendMulticastAsync(Message message)
+        {
+            if (_multicastClients != null)
+            {
+                foreach (var multicastClient in _multicastClients.Values)
+                {
+                    await multicastClient.SendAsync(message);
+                }
+            }
+        }
+        
         private static IEnumerable<IPAddress> GetNetworkInterfaceLocalAddresses(NetworkInterface networkInterface)
         {
             return networkInterface

--- a/src/AirDropAnywhere.Core/MulticastDns/MulticastDnsServer.cs
+++ b/src/AirDropAnywhere.Core/MulticastDns/MulticastDnsServer.cs
@@ -286,7 +286,8 @@ namespace AirDropAnywhere.Core.MulticastDns
                     .GetIPProperties()
                     .UnicastAddresses
                     .Select(x => x.Address)
-                    .Where(x => x.AddressFamily != AddressFamily.InterNetworkV6 || x.IsIPv6LinkLocal)
+                    .Where(ip => !IPAddress.IsLoopback(ip))
+                    .Where(ip => ip.AddressFamily != AddressFamily.InterNetworkV6 || ip.IsIPv6LinkLocal)
                 ;
         }
         

--- a/tests/AirDropAnywhere.Tests/AirDropAnywhere.Tests.csproj
+++ b/tests/AirDropAnywhere.Tests/AirDropAnywhere.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Implements #5 by advertising the HTTP endpoint provided by the AirDrop service and then supporting auto-discovery of that advertised address by a client using mDNS lookup of the PTR and SRV records.

## Changes

 - advertise `airdrop.local` as a instance of the mDNS service `_airdrop_proxy._tcp` when the server starts
 - rename `MulticastDnsServer` => `MulticastDnsManager` and make it `public`. Existing methods (peer registration) have been made `internal` and the class now implements a factory method (`CreateAsync`) which is used to initialize a new instance of the class.
 - `DiscoverAsync` performs the logic needed to asynchronously lookup `DnsEndPoint` instances associated with an mDNS service name
 - when a `ClientCommand` is executed without a server/port being passed we discover any instances of the `_airdrop_proxy._tcp` service using an instance of `MulticastDnsManager` and then connect to it directly
 - tweaked `launchSettings.json` for the "client" profile to execute in auto-discovery mode by default
 - persist certificate generation so we don't need to keep re-generating on every execution of the server
 - misc Resharper-isms

